### PR TITLE
The correct http status to use is 401 when login fails

### DIFF
--- a/repository/auth/auth.go
+++ b/repository/auth/auth.go
@@ -41,7 +41,7 @@ func (s *Service) Authenticate(c context.Context, email, password string) (*mode
 		return nil, apperr.Unauthorized
 	}
 	if !secret.New().HashMatchesPassword(u.Password, password) {
-		return nil, apperr.New(http.StatusNotFound, "Username or password does not exist")
+		return nil, apperr.Unauthorized
 	}
 	// user must be active and verified. Active is enabled/disabled by superadmin user. Verified depends on user verifying via /verification/:token or /mobile/verify
 	if !u.Active || !u.Verified {

--- a/repository/auth/auth.go
+++ b/repository/auth/auth.go
@@ -38,7 +38,7 @@ type JWT interface {
 func (s *Service) Authenticate(c context.Context, email, password string) (*model.AuthToken, error) {
 	u, err := s.userRepo.FindByEmail(email)
 	if err != nil {
-		return nil, err
+		return nil, apperr.Unauthorized
 	}
 	if !secret.New().HashMatchesPassword(u.Password, password) {
 		return nil, apperr.New(http.StatusNotFound, "Username or password does not exist")

--- a/service/auth_test.go
+++ b/service/auth_test.go
@@ -40,7 +40,7 @@ func TestLogin(t *testing.T) {
 		{
 			name:       "Fail on FindByUsername",
 			req:        `{"email":"juzernejm","password":"hunter123"}`,
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusUnauthorized,
 			userRepo: &mockdb.User{
 				FindByEmailFn: func(string) (*model.User, error) {
 					return nil, apperr.DB


### PR DESCRIPTION
Signed-off-by: Calvin Cheng <linchuan.cheng@gmail.com>
